### PR TITLE
Enhance Editors UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ FLATTEN
 UNIQUE
 ```
 
+### Repeated variables features
+
+This plugin support repeated variables. To use a repeated variable in your warpscript add the prefix `_repeat` to your variable name.
+
+Example for the variable `my_variable`:
+
+```warpscript
+$my_variable_repeat
+```
+
+If the panel is repeated, it will define this variable by its current value. 
+
 ### Templating variable evaluation
 
 To understand the variable resolution, this is how a query is built

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -22,7 +22,7 @@ export function ConfigEditor(props: Props) {
       ...options.jsonData,
       path: event.target.value,
     };
-    onOptionsChange({ ...options, jsonData });
+    onOptionsChange({ ...options, jsonData, url: event.target.value });
   };
 
   // Modification select access

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -24,7 +24,7 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
   if (!expr && expr !== '') {
     console.warn('Deprecate request detected');
     // @ts-ignore
-    expr = query.queryText;
+    expr = query.queryText ?? '';
   }
 
   //operations changes
@@ -39,7 +39,12 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
   );
 
   useEffect(() => {
-    let subscription = onChangeObservable.subscribe(() => onRunQuery());
+    let subscription = onChangeObservable.subscribe((value) => {
+      // check if the warpscript is empty
+      if ((value ?? '').trim() !== '') {
+        onRunQuery();
+      }
+    });
     return () => subscription.unsubscribe();
   }, [onChangeObservable, onRunQuery]);
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -3,7 +3,7 @@ import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { WarpDataSourceOptions, WarpQuery } from '../types/types';
 import { debounceTime, tap, Subject } from 'rxjs';
-import { TextArea } from '@grafana/ui';
+import { TextArea, Button } from '@grafana/ui';
 
 type Props = QueryEditorProps<DataSource, WarpQuery, WarpDataSourceOptions>;
 
@@ -52,9 +52,23 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
     subject.next(event.target.value);
   };
 
+  const handleRunQueryShortcut = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.ctrlKey && event.key === 'Enter') {
+      event.preventDefault();
+      onRunQuery();
+    }
+  };
+
   return (
-    <div className="gf-form" style={{ border: 'solid 1px #2e3136' }}>
-      <TextArea rows={nbrLinesText(expr)} value={expr} onChange={onExprChange} />
+    <div className="gf-form" style={{  display: 'flex', flexDirection: 'column' }}>
+      <TextArea rows={nbrLinesText(expr)} value={expr} onChange={onExprChange} onKeyDown={handleRunQueryShortcut} placeholder="Enter your query here (CTRL+ENTER to run)" />
+      <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-end', marginTop: '8px' }}>
+
+        {/* disabled if expr is empty */}
+        <Button variant="primary" style={{ }} onClick={onRunQuery} disabled={(expr ?? '').trim() === ''}>
+          Run query
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -114,7 +114,7 @@ export class DataSource extends DataSourceWithBackend<WarpQuery, WarpDataSourceO
       if (!t.expr && t.expr !== '') {
         console.warn('Deprecate request detected');
         // @ts-ignore
-        t.expr = t.queryText;
+        t.expr = t.queryText ?? '';
       }
       return t;
     });


### PR DESCRIPTION
**Enhance Request Editor UX: Manual Run Button, Shortcut, and URL Fix**

fix(editor): Request editor
-  Request editor return undefined error because the request is sent empty by default

fix(url): disappearance of url on manual creation
-  the url is set when we add a provionning pre defined datasource because the url is already set and applied as an option by default
- we weren't updating the plugin's options 'onOptionsChange'
